### PR TITLE
[2차시] 남우성- swea 3282

### DIFF
--- a/namws/2차시/swea_3282_D3.java
+++ b/namws/2차시/swea_3282_D3.java
@@ -1,0 +1,49 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Solution {
+	public static void main(String[] args)throws Exception{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringBuilder sb = new StringBuilder();
+		
+		int T = Integer.parseInt(br.readLine());
+		for(int testCase = 1; testCase <= T; testCase++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			
+			int N = Integer.parseInt(st.nextToken());
+			int K = Integer.parseInt(st.nextToken());
+
+			int[][] arr = new int[N][2];
+			for(int i = 0; i < N; i++) {
+				st = new StringTokenizer(br.readLine());
+
+				int a = Integer.parseInt(st.nextToken());
+				int b = Integer.parseInt(st.nextToken());
+				arr[i][0] = a;
+				arr[i][1] = b;
+			}
+			
+			Arrays.sort(arr, (a,b) -> Integer.compare(a[0], b[0])); // 물건의 부피 크기로 오름차순 정렬
+			
+			
+			int[] dp = new int[K+1]; //무게별 최대 가치를 dp로 계산
+			int[] past = new int[K+1]; // 이전 시행 결과
+			
+			for(int i = 0; i < N; i++) { // 각 item이 추가되었을 때 dp를 update
+				int volume = arr[i][0];
+				int value = arr[i][1];
+
+				for(int j = volume; j <= K; j++) {
+					dp[j] = Math.max(past[j], past[j - volume] + value); // item을 추가했을 때와 추가하지 않았을 때 중 더 큰 값을 저장
+				}
+				past = Arrays.copyOf(dp, dp.length);
+			}
+			
+			sb.append("#").append(testCase).append(" ").append(dp[K]).append("\n");
+		}
+		System.out.print(sb);
+	}
+}
+


### PR DESCRIPTION
# 문제 제목

## 📋 문제 정보
- **플랫폼**: SWEA
- **문제 번호**: 3282
- **난이도**: D3

---

## 🎯 문제 접근 방식

- **문제 분석 :**
- 2개 방식을 고민: dfs, dp
    - dfs로 풀면 각 item을 넣는 지 안 넣는지를 계속 탐색
    
    ⇒ O(2^N)의 시간복잡도
    
    - dp는 하나의 item에 대해 넣었을 때 최대값을 배열 길이만큼 update
    
    ⇒ O(N^K)의 시간복잡도

- **사용할 알고리즘/자료구조 :**
- 고민 결과 DP 사용하기로 결정, 자료구조는 단순 배열만 사용

---

## 📊 복잡도 분석

- **O(N*K)**
- 이유: N개의 item에 대해 각각 최대 K 만큼 배열을 update하므로 O(N * K)

---

## ⚡ 메모리/실행시간

### 결과
- **메모리**: 33,792 KB
- **실행시간**: 150 ms


