### PR TITLE
[5차시] 김성훈 - project_ssafy 2030, swea 1861

### DIFF
--- a/Teddysir/src/week02/day_0731/SWEA_1861.java
+++ b/Teddysir/src/week02/day_0731/SWEA_1861.java
@@ -1,0 +1,83 @@
+package practice;
+
+import java.io.*;
+import java.util.*;
+
+public class SWEA_1861 {
+
+	static int T, size, maxX, maxY, max, tempMax;
+	static int[][] map;
+	static int[] dx = { 1, -1, 0, 0 };
+	static int[] dy = { 0, 0, 1, -1 };
+
+	public static void main(String args[]) throws Exception {
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringBuilder sb = new StringBuilder();
+
+		T = Integer.parseInt(br.readLine());
+
+		for (int k = 1; k <= T; k++) {
+			size = Integer.parseInt(br.readLine());
+
+			map = new int[size][size];
+
+			for (int i = 0; i < size; i++) {
+				StringTokenizer st = new StringTokenizer(br.readLine());
+				for (int j = 0; j < size; j++) {
+					map[i][j] = Integer.parseInt(st.nextToken());
+				}
+			}
+			tempMax = 0;
+			max = 0;
+			maxX = 0;
+			maxY = 0;
+			for (int i = 0; i < size; i++) {
+				for (int j = 0; j < size; j++) {
+					tempMax = bfs(i, j);
+					if (tempMax == max) {
+						if (map[i][j] < map[maxX][maxY]) {
+							maxX = i;
+							maxY = j;
+						}
+					}
+					if (tempMax > max) {
+						max = tempMax;
+						maxX = i;
+						maxY = j;
+
+					}
+				}
+			}
+
+			sb.append("#").append(k).append(" ").append(map[maxX][maxY]).append(" ").append(max).append("\n");
+		}
+		System.out.println(sb);
+	}
+
+	static int bfs(int x, int y) {
+		Queue<int[]> q = new LinkedList<>();
+		q.add(new int[] { x, y });
+		int count = 1;
+
+		while (!q.isEmpty()) {
+			int temp[] = q.poll();
+
+			for (int i = 0; i < 4; i++) {
+				int nx = temp[0] + dx[i];
+				int ny = temp[1] + dy[i];
+
+				if (nx >= 0 && ny >= 0 && nx < size && ny < size) {
+					if (map[nx][ny] - 1 == map[nx - dx[i]][ny - dy[i]]) {
+						count++;
+						q.add(new int[] { nx, ny });
+					}
+				}
+			}
+
+		}
+
+		return count;
+	}
+
+}

--- a/Teddysir/src/week02/day_0731/SpiderWeb.java
+++ b/Teddysir/src/week02/day_0731/SpiderWeb.java
@@ -1,0 +1,96 @@
+package com.ssafy.hw.step4;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+import java.util.StringTokenizer;
+
+public class SpiderWeb {
+
+	static int N, max, maxX, maxY, tempTotal;
+	static int map[][];
+
+	static int[] dx = { 1, -1, 0, 0, -1, 1, -1, 1 };
+	static int[] dy = { 0, 0, 1, -1, 1, -1, -1, 1 };
+
+	public static void main(String[] args) throws Exception {
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringBuilder sb = new StringBuilder();
+		N = Integer.parseInt(br.readLine());
+		map = new int[N][N];
+
+		for (int i = 0; i < N; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			for (int j = 0; j < N; j++) {
+				map[i][j] = Integer.parseInt(st.nextToken());
+
+			}
+		}
+		max = 0;
+
+		for (int i = 0; i < N; i++) {
+			for (int j = 0; j < N; j++) {
+				int tempMax = search(i, j);
+				if (tempMax > max) {
+					max = tempMax;
+					maxX = i;
+					maxY = j;
+				}
+			}
+		}
+		
+		sb.append(max).append("\n");
+		sb.append(maxX).append(", ").append(maxY);
+
+		System.out.println(sb);
+		
+
+	}
+
+	static int search(int x, int y) {
+		tempTotal = 1;
+
+		for (int i = 0; i < 8; i++) {
+			tempTotal += search_dir(x, y, i);
+		}
+		return tempTotal;
+
+	}
+
+	static int search_dir(int x, int y, int dir) {
+
+		int nx = x + dx[dir];
+		int ny = y + dy[dir];
+
+		int obstacleCount = 0;
+		int one_dir_total = 0;
+
+		if (map[x][y] == 1) {
+			obstacleCount = 1;
+		}
+
+		while (true) {
+			
+	        if (nx < 0 || ny < 0 || nx >= N || ny >= N) {
+	            break; 
+	        }
+
+			if (map[nx][ny] == 1) {
+				obstacleCount++;
+				if (obstacleCount == 2) {
+					break;
+				}
+			} else {
+				one_dir_total++;
+				obstacleCount = 0;
+			}
+
+			nx += dx[dir];
+			ny += dy[dir];
+		}
+
+		return one_dir_total;
+
+	}
+}


### PR DESCRIPTION
# 거미줄 치기

## 📋 문제 정보
- **플랫폼**: Project SSAFY
- **문제 번호**: X
- **난이도**: Lv4

---

## 🎯 문제 접근 방식

- **문제 분석 :**
- 메모이제이션을 사용하면 뭔가 시간복잡도를 줄일 수 있을거 같다고 생각했습니다. 지난번 알고리즘장님의 시간복잡도를 개선하는 방식을  생각하며 해보려 했지만 막상 제대로 되지 않아 우선 다음과 같이 풀이를 하였습니다.
- 해당 좌표를 기준으로 8방탐색을 하며 한 방향마다 최대 거미줄을 칠 수 있는 값들을 더해서 그 좌표기준 거미줄 최대값들을 모든 좌표마다 시행하며 비교해서 답을 산출하는 방식으로 접근하였습니다.

- 문제 분석 및 나의 풀이
    - 2차원 배열 완전탐색
    - 좌표마다 8방탐색 및 전 방향 탐색하며 최대 거미줄수 리턴
    - 위 로직을 모든 좌표에서 다 비교하며 최대값 산출

---

## 📊 복잡도 분석

- 분석한 시간복잡도: O(N^3)

----
# 정사각형 

## 📋 문제 정보
- **플랫폼**: SWEA
- **문제 번호**: 1861
- **난이도**: D4

---

## 🎯 문제 접근 방식

- **문제 분석 :**
- 문제를 풀면서 단순히 BFS로 풀 생각을 하면서 틀대로 푸니까 쉽게 정답이 나왔던 문제 하지만
지난번 코드리뷰 코멘트중 탐색 최대범위를 미리계산하고 N^2 로직.. N^3.. 등 탐색 범위가 많아질경우 쉽게 시간초과가 날 거 같은 문제들은 미리 사전에 계산을 해보고 문제를 접근하는 방법을 간과하고 흐름대로 문제를 해결했더니 굉장히 비효율적인 코드가 발생하였음, 빠르게 리팩토링을 하고 코드를 추가수정 해보겠습니다.

- 문제 분석 및 나의 풀이
    - 2차원 배열 map 탐색
    - 모든 좌표를 기점으로 bfs 탐색을 실시함
    - 해당 좌표를 기점으로 bfs가 끝나면 리턴값이 크면 그 값을 최대값으로 저장하고 출력
    - 만약 리턴값이 같다면 시작지점 좌표값과 지난 max의 좌표값중 더 작은 좌표값을 저장함

---

## 📊 복잡도 분석

- 분석한 시간복잡도: O(N^2 * k) or 최대 O(N^4)까지도 걸릴 수 있다고 생각합니다....




