### PR TITLE
[7차시] 김성훈 - swea 7465

### DIFF
--- a/Teddysir/src/week02/day_0801/BOJ_7465.java
+++ b/Teddysir/src/week02/day_0801/BOJ_7465.java
@@ -1,0 +1,60 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_7465 {
+	static int N, M, T, ans;
+	static int[][] friends;
+	static boolean[] visited;
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringBuilder sb = new StringBuilder();
+
+		T = Integer.parseInt(br.readLine());
+
+		for (int k = 1; k <= T; k++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+
+			ans = 0;
+
+			N = Integer.parseInt(st.nextToken());
+			M = Integer.parseInt(st.nextToken());
+
+			friends = new int[N + 1][N + 1];
+			visited = new boolean[N + 1];
+
+			for (int i = 0; i < M; i++) {
+				st = new StringTokenizer(br.readLine());
+				int a = Integer.parseInt(st.nextToken());
+				int b = Integer.parseInt(st.nextToken());
+
+				friends[a][b] = friends[b][a] = 1;
+			}
+
+			for (int i = 1; i <= N; i++) {
+				if (!visited[i]) {
+					dfs(i);
+					ans++;
+				}
+			}
+
+			sb.append("#").append(k).append(" ").append(ans).append("\n");
+
+		}
+
+		System.out.println(sb);
+
+	}
+
+	static void dfs(int start) {
+		visited[start] = true;
+		for (int i = 1; i <= N; i++) {
+			if (friends[start][i] == 1 && !visited[i]) {
+				visited[i] = true;
+				dfs(i);
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
# 문제 제목

## 📋 문제 정보
- **플랫폼**: SWEA
- **문제 번호**: 7465
- **난이도**: D4

---

## 🎯 문제 접근 방식

- **문제 분석 :**
- 이전에 백준에서 풀었던 DFS와 BFS 문제풀이중 DFS와 매우 유사함을 느껴서 정답을 도출하는 방식만 약간 변경하여 문제를 해결할 수 있을것이라고 분석하였습니다.

- 문제 분석 및 나의 풀이
    - 1부터 시작하여 N까지 dfs를 진행함 
    - 만약 방문한게 아니라면 계속 dfs 
    - 이후 끝 노드까지 방문을 하면 방문하지 않은 노드부터 재 시작 
    - 새로운 노드부터 시작한만큼 ans++;

---

## 📊 복잡도 분석

- 분석한 시간복잡도: O(N^2)
    - 이유: for문을 두 번 사용하여 dfs를 이용하였기때문에 N^2의 시간복잡도를 갖습니다. 충분히 테스트 케이스를 보고 가능할 것 같다고 먼저 생각하고 접근을 해보았던 거 같습니다.

---

## ⚡ 메모리/실행시간
<img width="355" height="78" alt="image" src="https://github.com/user-attachments/assets/59383749-6b1e-4605-9203-c2f954f6a543" />


