### PR TITLE
 [7차시] 남우성 - swea 7465

### DIFF
--- a/namws/7차시/swea_7465.java
+++ b/namws/7차시/swea_7465.java
@@ -1,0 +1,71 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+public class Solution {
+	static int[] arr;
+	static int[] rank; //자신이 속한 그룹의 노드 개수를 저장
+	
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		StringBuilder sb = new StringBuilder();
+		
+		int T = Integer.parseInt(br.readLine());
+		
+		for(int testCase = 1; testCase <= T; testCase++) {
+			st = new StringTokenizer(br.readLine());
+			int n = Integer.parseInt(st.nextToken()); int m = Integer.parseInt(st.nextToken());
+			
+			arr = new int[n];
+			rank = new int[n];
+			
+			for(int i = 0; i < n; i++) {
+				arr[i] = i; //각자 자신의 그룹 대표로 설정
+				rank[i] = 1; //처음엔 각 그룹 별 개수가 1
+			}
+			
+			for(int i = 0; i < m; i++) { //무방향 그래프 입력 시 union 작업 수행
+				st = new StringTokenizer(br.readLine());
+				
+				int node1 = Integer.parseInt(st.nextToken()) - 1;
+				int node2 = Integer.parseInt(st.nextToken()) - 1;
+				
+				union(node1, node2);
+			}
+			
+			Set<Integer> result = new HashSet<Integer>();
+			for(int i = 0; i < n; i++) {
+				result.add(find(i)); // 대표 노드들을 결과에 포함
+			}
+			
+			sb.append("#").append(testCase).append(" ").append(result.size()).append("\n");
+		}
+		System.out.print(sb);
+	}
+	
+	public static void union(int node1, int node2) {
+		int stand1 = find(node1);
+		int stand2 = find(node2);
+		
+		if(stand1 == stand2) return; // 같은 집합이면 pass
+		
+		if(rank[stand1] < rank[stand2]) { // 더 작은 rank를 가진 집합을 더 큰 집합에 속하게 함 => 나중에 각 node의 대표를 update할 때 좀 더 효율적으로 하기 위함
+			arr[stand1] = stand2;
+			rank[stand2] += rank[stand1];
+		} else {
+			arr[stand2] = stand1;
+			rank[stand1] += rank[stand2]; 
+		}
+	}
+	
+	public static int find(int node) {
+		if(arr[node] == node) return node; // 자신이 대표라면 그대로 반환
+		else { // 아니라면 최상단 대표 노드를 찾아 저장 후 반환
+			arr[node] = find(arr[node]);
+			return arr[node];
+		}
+	}
+}


### PR DESCRIPTION
# 문제 제목

## 📋 문제 정보
- **플랫폼**: SWEA
- **문제 번호**: 7465
- **난이도**: D4

---

## 🎯 문제 접근 방식

**문제 분석 :**
- 문제를 읽고 전형적인 유니온파인드 문제라고 생각함
- 유니온파인드는 처음 해보는 알고리즘이라 금요일에 공부를 하고, 일요일에 코드로 풀이 해 봄
- find와 union 연산을 통해 각 집합을 update해 나감
- 여기서 rank 배열을 추가로 두고, union을 할때 더 사이즈가 작은 집합을 더 큰 집합에 포함시킴
(이렇게 하면 나중에 find 연산을 할 때, 더 적은 횟수로 연산을 할 수 있음)


---

## 📊 복잡도 분석

- 분석한 시간복잡도: O(M + N)
    - 이유: 유니온 파인드에서 union과 find 연산은 모두 O(α(n))의 시간복잡도를 가징
    - O(α(n))은 아커만 역함수로 사실상 상수와 동일(n ≈ 2^65536이어야 α(n) = 5)
    - 총 m번의 유니온 ⇒ O(m * α(n))
    - 총 n번의 파인드 ⇒ O(n * α(n))
    => 총 복잡도는 O(m + n)

---

## ⚡ 메모리/실행시간
### 결과
<img width="1032" height="76" alt="image" src="https://github.com/user-attachments/assets/7c4906ff-0d2b-4461-a516-76e05a96ff69" />


### 기타 회고
- 유니온파인드를 깊게 공부할 수 있어서 좋았음
=> 유니온 파인드의 핵심 개념이 경로 압축을 통한 저장임을 이해함
- 이 문제에서는 오히려 rank를 도입한 것이 더 느리게 나온 것 같음. rank 배열 자체가 노드 수가 굉장히 많을 때 유의미한 성능 차이를 보이는 것으로 알고 있기는 해서 rank를 도입할 지 말지는 잘 고민해봐야 할 듯

