### PR TITLE
[8차시] 남우성 - swea 5643

### DIFF
--- a/namws/8차시/swea_5634.java
+++ b/namws/8차시/swea_5634.java
@@ -1,0 +1,87 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Solution {
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		StringBuilder sb = new StringBuilder();
+		
+		int T = Integer.parseInt(br.readLine());
+		
+		for(int testCase = 1; testCase <= T; testCase++) {
+			int N = Integer.parseInt(br.readLine());
+			int M = Integer.parseInt(br.readLine());
+			
+			List<List<Integer>> graph = new ArrayList<>(); // 그래프
+			List<List<Integer>> reGraph = new ArrayList<>(); // 역방향 그래프
+
+			for(int i = 0; i < N; i++) {
+				graph.add(new ArrayList<>());
+				reGraph.add(new ArrayList<>());
+			}
+			
+			for(int i = 0; i < M; i++) {
+				st = new StringTokenizer(br.readLine());
+				int a = Integer.parseInt(st.nextToken()) - 1; int b = Integer.parseInt(st.nextToken()) - 1;
+				graph.get(a).add(b);
+				reGraph.get(b).add(a);
+			}
+			
+			int result = 0;
+			
+			
+			for(int i = 0; i < N; i++) {
+				boolean[] isVisited = new boolean[N];
+				int cnt = 0;
+				
+				Deque<Integer> queue = new ArrayDeque<>();
+				queue.add(i);
+				isVisited[i] = true;
+				while(!queue.isEmpty()) { //bfs 탐색(그래프 방향)
+					int now = queue.poll();
+					cnt++;
+					
+					for(int temp = 0; temp < graph.get(now).size(); temp++) {
+						int next = graph.get(now).get(temp);
+						if(!isVisited[next]) {
+							queue.add(next);
+							isVisited[next] = true;
+						}
+					}
+				}
+				
+				queue = new ArrayDeque<>();
+				isVisited = new boolean[N];
+				queue.add(i);
+				isVisited[i] = true;
+				while(!queue.isEmpty()) { //bfs 탐색(그래프 반대 방향)
+					int now = queue.poll();
+					cnt++;
+					
+					for(int temp = 0; temp < reGraph.get(now).size(); temp++) {
+						int next = reGraph.get(now).get(temp);
+						if(!isVisited[next]) {
+							queue.add(next);
+							isVisited[next] = true;
+						}
+					}
+				}
+				
+				cnt--;
+				if(cnt == N) {
+					result++;
+				}
+			}
+			
+			
+			sb.append("#").append(testCase).append(" ").append(result).append("\n");
+		}
+		System.out.print(sb);
+	}
+}


### PR DESCRIPTION
# 문제 제목

## 📋 문제 정보
- **플랫폼**: SWEA
- **문제 번호**: 5643
- **난이도**: D4

---

## 🎯 문제 접근 방식

**문제 분석 :**
- 문제를 읽고 처음에는 전형적인 위상정렬이라고 생각함
    - 근데 위상정렬은 순서만 맞춰서 일렬로 줄 세우는 알고리즘인데 이 문제에서는 순서가 확정된 노드의 개수를 세는 문제라 당황함
- 그래서 단순 그래프 탐색이 정석이라고 생각함
    - dfs나 bfs의 그래프 탐색: O(N^2)인데, 이걸 위상정렬을 쓰면 O(NlogN)으로 줄일 수 있지 않을까 고민함..
    - 근데 아무리 생각해도 너무 어려워서 포기.. 
 
**문제풀이**
- 순방향 그래프와 역방향 그래프를 2개를 입력받음
- 그리고 각 노드별 2 방향 모두 전개를 시켰을 때 모든 노드를 거친다면, 해당 노드는 모든 노드에 대해 자신의 위치를 알 수 있는 노드라고 판단
- 만약 하나의 노드라도 거치지 않는다면, 해당 노드와는 순서를 가릴 수 없으니 count 하지 않음


---

## 📊 복잡도 분석

- 분석한 시간복잡도: O(N^2)
    - 이유: 총 N개의 노드에 대해 각각 dfs를 2번 수행해서 2N => O(N^2)

---

## ⚡ 메모리/실행시간
### 결과
<img width="1176" height="82" alt="image" src="https://github.com/user-attachments/assets/fadcf295-d9d0-4d18-9b44-f6a967625ce4" />


### 기타 회고
- 일단 이 문제 고민에 시간을 너무 많이 써서 가장 기본적인 풀이로 풀기는 했는데... 최적화 방법이 무조건 있을 것 같아서 나중에 시간 될 때 더 고민해보기로 함...
- 위상정렬을 도입하거나 혹은 각 노드별 경로 개수를 메모리제이션 해서 DP 개념도 적용할 것 같음

